### PR TITLE
Implement attention-based BEV fusion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
     * 使用OpenCV对2D特征图进行逆透视变换，将其“拍扁”并投影到预定义的BEV世界坐标系下的虚拟“地面”上。
 
 4.  **BEV特征融合 (BEV Fusion)**:
-    * 将来自N个摄像头的BEV特征图进行融合，生成一张单一的、信息增强的BEV特征图。
+    * 将来自N个摄像头的BEV特征图进行融合，生成一张单一的、信息增强的BEV特征图。仓库提供了逐元素 `SimpleFusion`、沿通道拼接的 `ConcatFusion` 以及跨视角注意力池化的 `AttentionFusion`，可通过配置 `MODEL.FUSION.TYPE` 在三者之间切换。
 
 5.  **下游任务头 (Downstream Heads)**:
     * 在融合后的BEV特征图上，接入不同的任务头来完成特定任务：

--- a/docs/TRAINING_FEASIBILITY_PLAN.md
+++ b/docs/TRAINING_FEASIBILITY_PLAN.md
@@ -36,7 +36,7 @@
    - 可引入 mixup/cutmix 的多视角变体以增强鲁棒性，注意保持几何关系。
 
 2. **多尺度特征**
-   - 若采用 `ConcatFusion`，随着视角数增加通道数迅速膨胀。考虑引入 1×1 conv 压缩或改为 attention fusion，参考 MVDet 的 transformer-style 融合策略。【F:project/models/model_wrapper.py†L35-L74】
+   - 若采用 `ConcatFusion`，随着视角数增加通道数迅速膨胀。现在已提供 `AttentionFusion`（跨视角多头注意力池化）可直接通过 `MODEL.FUSION.TYPE=attention` 启用，以控制通道尺寸并自适应分配视角权重；仍可结合 1×1 conv 做进一步压缩。【F:project/models/model_wrapper.py†L35-L75】
 
 3. **几何一致性正则**
    - 激活 `_geom_consistency_loss`，在 `loss` 中按权重加入，可缓解标定噪声造成的 BEV 偏移。【F:project/models/model_wrapper.py†L121-L151】


### PR DESCRIPTION
## Summary
- add a cross-view AttentionFusion module based on multi-head attention and wire it into BEVNet via the MODEL.FUSION config
- document the new fusion choices across the README and detailed docs, including guidance in the training feasibility plan

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69167612ed348325834b6baa001cb2e4)